### PR TITLE
Modernize GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,16 +1,16 @@
 name: Deploy to WordPress.org
 on:
-  push:
-    tags:
-      - "*"
+    push:
+        tags:
+            - '*'
 jobs:
-  tag:
-    name: New tag
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: WordPress Plugin Deploy
-        uses: 10up/action-wordpress-plugin-deploy@stable
-        env:
-          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+    tag:
+        name: New tag
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - name: WordPress Plugin Deploy
+              uses: 10up/action-wordpress-plugin-deploy@stable
+              env:
+                  SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+                  SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/push-asset-readme-update.yml
+++ b/.github/workflows/push-asset-readme-update.yml
@@ -1,16 +1,16 @@
 name: Plugin asset/readme update
 on:
-  push:
-    branches:
-      - trunk
+    push:
+        branches:
+            - trunk
 jobs:
-  trunk:
-    name: Push to trunk
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@master
-      - name: WordPress.org plugin asset/readme update
-        uses: 10up/action-wordpress-plugin-asset-update@stable
-        env:
-          SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
-          SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+    trunk:
+        name: Push to trunk
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+            - name: WordPress.org plugin asset/readme update
+              uses: 10up/action-wordpress-plugin-asset-update@stable
+              env:
+                  SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+                  SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/wpcs.yml
+++ b/.github/workflows/wpcs.yml
@@ -1,33 +1,32 @@
 name: PHPCS check
-on:
-  push
+on: push
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+    group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+    cancel-in-progress: true
 
 jobs:
-  phpcs:
-    name: PHPCS check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+    phpcs:
+        name: PHPCS check
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6
 
-      - name: Setup PHP
-        uses: "shivammathur/setup-php@v2"
-        with:
-          php-version: "7.4"
-          ini-values: "memory_limit=1G"
-          coverage: none
-          tools: cs2pr
+            - name: Setup PHP
+              uses: 'shivammathur/setup-php@v2'
+              with:
+                  php-version: '7.4'
+                  ini-values: 'memory_limit=1G'
+                  coverage: none
+                  tools: cs2pr
 
-      - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v2"
+            - name: Install Composer dependencies
+              uses: 'ramsey/composer-install@v4'
 
-      - name: Run PHPCS checks
-        continue-on-error: true
-        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml --standard=WordPress --extensions=php --ignore="node_modules,vendor" .
+            - name: Run PHPCS checks
+              continue-on-error: true
+              run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml --standard=WordPress --extensions=php --ignore="node_modules,vendor" .
 
-      - name: Show PHPCS results in PR
-        run: cs2pr ./phpcs-report.xml
+            - name: Show PHPCS results in PR
+              run: cs2pr ./phpcs-report.xml


### PR DESCRIPTION
Modernize GitHub Actions workflow versions and formatting across this repo.

**Action version bumps to latest majors:**
- `actions/checkout`: `@master`/`@v1`/`@v3`/`@v4` → `@v6` (`@master` is unpinned and can break unannounced)
- `actions/setup-node`: `@v4` → `@v6`
- `actions/cache`: `@v4` → `@v5`
- `actions/upload-artifact`: `@v4` → `@v7`
- `actions/create-github-app-token`: `@v2` → `@v3`
- `softprops/action-gh-release`: `@v2` → `@v3`
- `peter-evans/find-comment`: `@v2` → `@v4`
- `peter-evans/create-or-update-comment`: `@v3` → `@v5`
- `ramsey/composer-install`: `@v2` → `@v4`

(Only the bumps actually present in this repo apply; the list above is the cohort-wide canonical.)

**Special migration (wp-author-slug only):**
- `actions/create-release@v1` → `softprops/action-gh-release@v3`. The original `actions/create-release` repo has been archived by GitHub; `softprops/action-gh-release` is the modern equivalent that the rest of this cohort already uses.

**Formatting:**
- Reformatted all workflow files via `npx -p prettier@3 -p @wordpress/prettier-config prettier --write '.github/workflows/*.yml'` to match the wp-scripts canonical style (4-space YAML indentation).

This is a coordinated cleanup across 10 plugin repos owned by @obenland; the version targets and formatting are identical across the cohort to keep them consistent.