### PR TITLE
Use mergeStateStatus to choose between immediate and auto-merge

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -86,7 +86,7 @@ jobs:
                   branch: chore/tested-up-to-${{ steps.wp.outputs.version }}
                   delete-branch: true
 
-            - name: Merge PR (auto if checks required, immediate otherwise)
+            - name: Merge PR
               if: steps.pr.outputs.pull-request-number
               shell: bash
               env:
@@ -94,22 +94,29 @@ jobs:
                   PR: ${{ steps.pr.outputs.pull-request-number }}
               run: |
                   set -euo pipefail
-                  # Try auto-merge first (queues the PR if any required checks are pending,
-                  # forward-compat for adding required checks to trunk later). GitHub rejects
-                  # auto-merge with "is in clean status" when the PR is already mergeable —
-                  # in that case we fall back to an immediate merge.
-                  auto_err=$(mktemp)
-                  if gh pr merge --auto --squash --delete-branch "$PR" 2>"$auto_err"; then
-                      echo "Auto-merge enabled for PR #$PR; waiting for it to complete."
-                  elif grep -q "in clean status" "$auto_err"; then
-                      echo "PR #$PR is already mergeable; merging immediately."
-                      gh pr merge --squash --delete-branch "$PR"
-                  else
-                      cat "$auto_err" >&2
-                      exit 1
-                  fi
-                  # Wait for the merge to actually complete before any downstream step,
-                  # so the SVN sync below cannot publish ahead of trunk.
+                  # Wait briefly for GitHub to finish computing mergeability for the new PR.
+                  for _ in $(seq 1 12); do
+                      state=$(gh pr view "$PR" --json mergeStateStatus --jq '.mergeStateStatus')
+                      [ "$state" != "UNKNOWN" ] && break
+                      sleep 5
+                  done
+                  echo "PR #$PR mergeStateStatus: $state"
+                  case "$state" in
+                      CLEAN | UNSTABLE)
+                          # No required checks blocking — merge immediately.
+                          gh pr merge --squash --delete-branch "$PR"
+                          ;;
+                      BLOCKED | BEHIND)
+                          # Required checks pending or branch behind base — queue for auto-merge.
+                          gh pr merge --auto --squash --delete-branch "$PR"
+                          ;;
+                      *)
+                          echo "PR #$PR is in unexpected state: $state" >&2
+                          exit 1
+                          ;;
+                  esac
+                  # Poll until the merge actually completes, so the SVN sync below cannot
+                  # publish ahead of trunk when --auto was used.
                   for _ in $(seq 1 60); do
                       merged_at=$(gh pr view "$PR" --json mergedAt --jq '.mergedAt')
                       if [ "$merged_at" != "null" ] && [ -n "$merged_at" ]; then


### PR DESCRIPTION
Replaces the `mktemp` + stderr-grep fallback with a structured check based on `gh pr view --json mergeStateStatus`:

- **CLEAN / UNSTABLE** → merge immediately (`gh pr merge --squash`).
- **BLOCKED / BEHIND** → queue for auto-merge (`gh pr merge --auto --squash`).
- **UNKNOWN** is briefly retried (mergeability still being computed by GitHub right after PR creation).
- Anything else fails the step with a clear error.

Removes the temp file (no more `mktemp` cleanup concerns) and stops parsing human-readable error text, so a future change to gh CLI wording cannot regress the cron path. Still forward-compat with required status checks being added to `trunk` later — the BLOCKED branch handles that case.