### PR TITLE
Convert readme.txt to README.md

### DIFF
--- a/.github/workflows/update-tested-up-to.yml
+++ b/.github/workflows/update-tested-up-to.yml
@@ -31,7 +31,7 @@ jobs:
         steps:
             - uses: actions/checkout@v6
               with:
-                  sparse-checkout: readme.txt
+                  sparse-checkout: README.md
                   sparse-checkout-cone-mode: false
 
             - name: Compare latest WordPress against readme
@@ -49,9 +49,9 @@ jobs:
                       echo "Failed to derive major.minor from '$latest'" >&2
                       exit 1
                   fi
-                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  current=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' README.md)
                   if [ -z "$current" ]; then
-                      echo "Could not find 'Tested up to:' header in readme.txt" >&2
+                      echo "Could not find 'Tested up to:' header in README.md" >&2
                       exit 1
                   fi
                   sorted=$(printf '%s\n%s\n' "$current" "$short" | sort -V)
@@ -205,15 +205,15 @@ jobs:
         steps:
             - uses: actions/checkout@v6
 
-            - name: Update readme.txt
+            - name: Update README.md
               shell: bash
               env:
                   TARGET: ${{ needs.check.outputs.version }}
                   PREVIOUS: ${{ needs.check.outputs.previous }}
               run: |
                   set -euo pipefail
-                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" readme.txt
-                  new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' readme.txt)
+                  sed -i -E "s/^([Tt]ested up to:[[:space:]]+).*/\1$TARGET/" README.md
+                  new=$(sed -nE '/^[Tt]ested up to:/{s/^[Tt]ested up to:[[:space:]]+//;s/\r$//;p;q;}' README.md)
                   if [ "$new" != "$TARGET" ]; then
                       echo "sed did not produce expected value (got '$new')" >&2
                       exit 1
@@ -230,7 +230,7 @@ jobs:
                   body: |
                       WordPress ${{ needs.check.outputs.full }} is the latest stable release.
 
-                      Bumps `Tested up to` in readme.txt from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
+                      Bumps `Tested up to` in README.md from ${{ needs.check.outputs.previous }} to ${{ needs.check.outputs.version }} (major.minor of ${{ needs.check.outputs.full }}).
                   branch: chore/tested-up-to-${{ needs.check.outputs.version }}
                   delete-branch: true
 
@@ -283,7 +283,7 @@ jobs:
                   set -euo pipefail
                   # peter-evans/create-pull-request leaves the working tree at the pre-PR
                   # state, and the merge happens on the remote. Pull the post-merge trunk
-                  # so the SVN sync below copies the actually-bumped readme.txt rather than
+                  # so the SVN sync below copies the actually-bumped README.md rather than
                   # the workspace's stale copy.
                   git fetch origin trunk
                   git reset --hard origin/trunk

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-=== WP Display Header ===
+# WP Display Header
 Contributors: obenland
 Tags: admin, custom header, header, header image, custom header image, display header, display dynamic header, custom, dynamic, fast, header, image, images, page, plugin, posts
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MWUA92KA2TL6Q
@@ -8,7 +8,7 @@ Stable tag: 7
 
 Select a specific header or random header image for each content item or archive page.
 
-== Description ==
+## Description
 
 This plugin lets you specify a header image for each post, page, custom post type or archive page individually, from your default headers and custom headers.
 
@@ -18,16 +18,16 @@ There is no change of template files necessary as this plugin hooks in the exist
 
 Thanks to Erik T. for the idea to this plugin!
 
-== Installation ==
+## Installation
 
 1. Download WP Display Header.
 2. Unzip the folder into the `/wp-content/plugins/` directory
 3. Activate the plugin through the 'Plugins' menu in WordPress
 
 
-== Frequently Asked Questions ==
+## Frequently Asked Questions
 
-= What do I need in the `header.php` file to make the plugin work seamlessly? =
+### What do I need in the `header.php` file to make the plugin work seamlessly?
 To make it work in your `header.php` file all you need is a `header_image()` call like so:
 
 `<img src="<?php header_image(); ?>" width="<?php echo get_custom_header()->width; ?>" height="<?php echo get_custom_header()->height; ?>" alt="" />`
@@ -35,7 +35,7 @@ To make it work in your `header.php` file all you need is a `header_image()` cal
 See TwentyTwelve's `header.php` for reference.
 
 
-= Plugin Filter Hooks =
+### Plugin Filter Hooks
 
 **wpdh_show_default_header** (*bool*)
 > Whether to show the default header (true) or to look for a specifically selected header for the current request.
@@ -50,94 +50,94 @@ See TwentyTwelve's `header.php` for reference.
 > The url to the currently active header image.
 
 
-== Screenshots ==
+## Screenshots
 
 1. The meta box in the main column.
 2. The meta box in the side column.
 
 
-== Changelog ==
+## Changelog
 
-= 7 =
+### 7
 * Fixes a bug where posts pages would not load their assigned header image. See https://github.com/obenland/wp-display-header/issues/3
 * Updated utility class.
 * Tested for WordPress 6.1.
 
-= 6 =
+### 6
 * Fixed a bug where srcset information for header images overrode custom header selections.
 
-= 5 =
+### 5
 * Maintenance release.
 * Updated code to adhere to WordPress Coding Standards.
 * Tested for WordPress 5.0.
 
-= 4 =
+### 4
 * Fixed a bug where styles were not enqueued correctly in wp-admin.
 * Now correctly displays the selection for header images on term edit pages again.
 * Tested for WordPress 4.6.0.
 
-= 3 =
+### 3
 * Maintenance release.
 * Some minor code cleanups.
 * Tested for WordPress 4.4.0.
 
-= 2.2.0 =
+### 2.2.0
 * Maintenance release.
 * Some minor code cleanups.
 * Tested for WordPress 4.0.
 
-= 2.1.0 =
+### 2.1.0
 * Added an option to not display a header at all.
 * Updated utility class.
 * Tested for WordPress 3.6.
 
-= 2.0.1 =
+### 2.0.1
 * Fixed a bug, where the fallback to the default header did not work. Props carloscorrela.
 
-= 2.0.0 =
+### 2.0.0
 * **IMPORTANT**: Version 2.0.0 breaks compatibility with WordPress versions **prior** to 3.2!
 * Added the header selection field to Taxonomy and Author Edit screens.
 * Fixed a minor bug for themes that have no header images registered.
 
-= 1.5.3 =
+### 1.5.3
 * Improved user experience when current theme does not support custom headers, on activation of the plugin.
 * Deprecated settings functions for WP Save Custom Header in preparation for overhaul in v2.0.0.
 * Updated utility class.
 
-= 1.5.2 =
+### 1.5.2
 * Fixed a bug, where a selected header wouldn't override the default selection on posts pages.
 
-= 1.5.1 =
+### 1.5.1
 * Specific headers can now be reverted by selecting the default header.
 
-= 1.5 =
+### 1.5
 * Adjusted meta box layout to WordPress core.
 * Transfered CSS in external file.
 * Updated FAQ section. Props Brian.
 * Tested for WordPress 3.3.1.
 
-= 1.4 =
+### 1.4
 * Added support for WordPress 3.2 core header uploads.
 
-= 1.3 =
+### 1.3
 * Tested for WordPress 3.2-beta
 * Fixed a minor bug where a PHP warning was issued in the edit-post-screen, when there are no header images registered.
 
-= 1.2.1 =
+### 1.2.1
 * WordPress Plugin Repository update bug.
 
-= 1.2 =
+### 1.2
 * Tested for WordPress 3.1.2.
 * Now a custom folder name can be specified. See: Settings > Media.
 * Added Italian translation. Props Pietro Rossi.
 
-= 1.1 =
+### 1.1
 * Tested for WordPress 3.1.1
 * Adopted [WP Save Custom Header](http://wordpress.org/extend/plugins/wp-save-custom-header/ "This plugin lets you save and reuse your uploaded header images.") multisite capability.
 * Made HTML W3C valid.
 
-= 1.0 =
+### 1.0
 * Initial Release.
 
-== Upgrade Notice ==
+## Upgrade Notice
 Maintenance update


### PR DESCRIPTION
## Summary

Renames `readme.txt` to `README.md` (GitHub renders it on the repo home) without giving up the wp.org plugin page.

WordPress.org's plugin-directory parser accepts either filename — its lookup regex is `!(?:^|/)readme\.(txt|md)$!i` (case-insensitive, .md included) — and the section grammar already supports `##` headers alongside `==`. The WP field block (`Contributors:`, `Tested up to:`, `Stable tag:`, …) stays in the same `Field: Value` format in both files. Within sections, `### x.y.z` becomes the changelog entry form (since `###` doesn't end a section).

Workflows that read or write the readme are updated to point at `README.md`:

- `update-tested-up-to.yml` — sparse-checkout, the `[Tt]ested up to:` sed/grep, and the PR body
- `push-asset-readme-update.yml` / `plugin-asset-update.yml` — path triggers
- `phpunit*.yml`, `playwright*.yml`, `test-e2e.yml` — `paths-ignore` arrays

For uploads-unleashed, `release.yml`'s changelog-insertion logic is also rewritten: it now greps for `^### <tag>$` and inserts after `^## Changelog`, and `.distignore` no longer excludes `README.md` from the SVN sync.

## Test plan

- [ ] GitHub renders README.md on the repo home.
- [ ] Next scheduled `update-tested-up-to` run finds the `Tested up to:` header in README.md and behaves the same as before.
- [ ] wp.org plugin page continues to show the readme content on the next deploy (parser picks up README.md via the case-insensitive lookup).
