### PR TITLE
Bump Stable tag to 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tags: header image, custom header, display header, dynamic, posts
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MWUA92KA2TL6Q
 Requires at least: 3.2
 Tested up to: 6.9
-Stable tag: 7
+Stable tag: 8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary

v8 was tagged and deployed earlier today but \`Stable tag\` in trunk/README.md still pointed at \`7\`. wp.org therefore kept rendering \`tags/7/README.md\` — and \`tags/7/\` also contains the original \`readme.txt\` (which the parser prefers over .md when both are present), so the plugin page never picked up the License header or the trimmed tag list from the recent cleanup PRs.

Bumping \`Stable tag: 7\` → \`Stable tag: 8\` here. On merge, \`push-asset-readme-update.yml\` will sync the README to \`SVN /trunk/\` and \`SVN /tags/8/\` (the asset-update action already does this — see r3531237 which touched both \`/trunk/\` and \`/tags/7/\`). wp.org will then read \`tags/8/README.md\` which has clean content and no leftover \`readme.txt\`.

## Test plan

- [ ] After merge, the push-asset-readme-update workflow run succeeds.
- [ ] \`svn cat https://plugins.svn.wordpress.org/wp-display-header/trunk/README.md\` shows \`Stable tag: 8\`.
- [ ] \`https://wordpress.org/plugins/wp-display-header/\` reflects the License header and the 5 curated tags within a few minutes of the importer running.