### PR TITLE
Bump Version to 8

### DIFF
--- a/wp-display-header.php
+++ b/wp-display-header.php
@@ -3,7 +3,7 @@
  * Plugin Name: WP Display Header
  * Plugin URI:  http://en.wp.obenland.it/wp-display-header/?utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-display-header
  * Description: This plugin lets you specify a header image for each post and taxonomy/author archive page individually, from your default headers and custom headers.
- * Version:     7
+ * Version:     8
  * Author:      Konstantin Obenland
  * Author URI:  http://en.wp.obenland.it/?utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-display-header
  * Text Domain: wp-display-header


### PR DESCRIPTION
## Summary

When v8 was tagged earlier today, the plugin file header still said \`Version: 7\` — so \`tags/8/wp-display-header.php\` was deployed with \`Version: 7\` inside, and wp.org's plugin info API reports \`version: 7\` even though tags/8 is now the stable target.

Bumping \`Version: 7\` -> \`Version: 8\` in wp-display-header.php here.

## After merge

The \`push-asset-readme-update.yml\` workflow won't sync this change (it only ships readme + .wordpress-org assets). To actually update \`tags/8\` with the new Version header, re-tag:

\`\`\`bash
git tag -d 8
git push origin :refs/tags/8
git tag 8
git push origin 8
\`\`\`

\`deploy.yml\` will fire on the new tag push, re-create \`tags/8\` from the now-bumped trunk, and wp.org will report \`version: 8\`.

## Test plan

- [ ] After re-tag, \`svn cat https://plugins.svn.wordpress.org/wp-display-header/tags/8/wp-display-header.php\` shows \`* Version:     8\`.
- [ ] \`api.wordpress.org/plugins/info/1.0/wp-display-header.json\` reports \`"version": "8"\`.