### PR TITLE
Fix undefined $tt_id warning in get_active_tax_header()

### DIFF
--- a/class-obenland-wp-display-header.php
+++ b/class-obenland-wp-display-header.php
@@ -489,18 +489,16 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 	 * @return string
 	 */
 	protected function get_active_tax_header() {
-		$active = get_option( 'wpdh_tax_meta', false );
-
-		if ( $active ) {
-			$tt_id  = get_queried_object()->term_taxonomy_id;
-			$active = isset( $active[ $tt_id ] ) ? $active[ $tt_id ] : '';
-		}
+		$queried_object = get_queried_object();
+		$tt_id          = isset( $queried_object->term_taxonomy_id ) ? $queried_object->term_taxonomy_id : null;
+		$tax_meta       = get_option( 'wpdh_tax_meta', array() );
+		$active         = ( $tt_id && isset( $tax_meta[ $tt_id ] ) ) ? $tax_meta[ $tt_id ] : '';
 
 		/**
 		 * Filters the active header for the current taxonomy.
 		 *
-		 * @param string $header Active header.
-		 * @param int    $tt_id  Term taxonomy ID.
+		 * @param string   $header Active header.
+		 * @param int|null $tt_id  Term taxonomy ID, or null if the queried object is not a term.
 		 */
 		return apply_filters( 'wpdh_get_active_tax_header', $this->get_active_header( $active ), $tt_id );
 	}

--- a/class-obenland-wp-display-header.php
+++ b/class-obenland-wp-display-header.php
@@ -492,7 +492,7 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 		$queried_object = get_queried_object();
 		$tt_id          = isset( $queried_object->term_taxonomy_id ) ? $queried_object->term_taxonomy_id : null;
 		$tax_meta       = get_option( 'wpdh_tax_meta', array() );
-		$active         = ( $tt_id && isset( $tax_meta[ $tt_id ] ) ) ? $tax_meta[ $tt_id ] : '';
+		$active         = ( $tt_id && is_array( $tax_meta ) && isset( $tax_meta[ $tt_id ] ) ) ? $tax_meta[ $tt_id ] : '';
 
 		/**
 		 * Filters the active header for the current taxonomy.

--- a/tests/e2e/wp-display-header.spec.ts
+++ b/tests/e2e/wp-display-header.spec.ts
@@ -8,7 +8,7 @@ import { loginAsAdmin, wp } from './utils';
  * `custom-header`. wp-env is configured to install + activate
  * Twenty Seventeen, which does support it.
  *
- * Three things to pin:
+ * Four things to pin:
  *
  * 1. The Header meta box is added to the post edit screen — the
  *    plugin's main user-facing control. If the meta box never renders,
@@ -23,10 +23,18 @@ import { loginAsAdmin, wp } from './utils';
  *
  * 3. With no override saved, the same filter chain returns the input
  *    unchanged. The plugin must not regress the unmodified path.
+ *
+ * 4. Taxonomy archives render without PHP warnings whether or not the
+ *    `wpdh_tax_meta` option holds a usable value, and honour a header
+ *    saved for the term. See the taxonomy describe block below for why
+ *    the warning, rather than the returned header, is what's asserted.
  */
 
 const OVERRIDE_URL =
 	'https://example.com/wp-content/uploads/wpdh-test-header.jpg';
+
+/** Disambiguates categories created within the same millisecond. */
+let uniqueSuffix = 0;
 
 /**
  * Asks wp-cli to apply `theme_mod_header_image` in a singular-post
@@ -53,6 +61,92 @@ $wp_the_query = $q;
 // the input default.
 $q->the_post();
 echo apply_filters( 'theme_mod_header_image', '${ defaultHeader }' );`,
+	] );
+}
+
+/**
+ * Applies `theme_mod_header_image` in a category archive context. The
+ * plugin's callback only consults `wpdh_tax_meta` when `is_category()`
+ * is true, and reads the term from `get_queried_object()`, so the wp
+ * eval builds a category `WP_Query` and assigns it to both `$wp_query`
+ * and `$wp_the_query`. No `the_post()` here — unlike the post path,
+ * `get_active_tax_header()` never touches the loop.
+ */
+function applyHeaderFilterForCategory(
+	termId: string,
+	defaultHeader: string
+): string {
+	return wp( [
+		'eval',
+		`global $wp_query, $wp_the_query;
+$q = new WP_Query( array( 'cat' => ${ termId } ) );
+$wp_query = $q;
+$wp_the_query = $q;
+echo apply_filters( 'theme_mod_header_image', '${ defaultHeader }' );`,
+	] );
+}
+
+/**
+ * Creates a category with one published post in it, so the archive is a
+ * real query with results rather than a 404.
+ *
+ * The name is suffixed to keep it unique: `wp term create` fails on a
+ * duplicate name, and wp-env keeps its database between runs.
+ *
+ * @param name Category name.
+ * @return The term ID and its term taxonomy ID — `wpdh_tax_meta` is
+ *         keyed by the latter, and the two are not interchangeable.
+ */
+function createCategoryWithPost( name: string ): {
+	termId: string;
+	ttId: string;
+} {
+	const uniqueName = `${ name } ${ Date.now() }-${ uniqueSuffix++ }`;
+	const termId = wp( [
+		'term',
+		'create',
+		'category',
+		uniqueName,
+		'--porcelain',
+	] );
+	const ttId = wp( [
+		'term',
+		'get',
+		'category',
+		termId,
+		'--field=term_taxonomy_id',
+	] );
+
+	wp( [
+		'post',
+		'create',
+		'--post_type=post',
+		'--post_status=publish',
+		`--post_title=${ uniqueName } post`,
+		`--post_category=${ termId }`,
+		'--porcelain',
+	] );
+
+	return { termId, ttId };
+}
+
+/**
+ * Empties debug.log so a following page load can be asserted on in
+ * isolation.
+ */
+function truncateDebugLog(): void {
+	wp( [ 'eval', "file_put_contents( WP_CONTENT_DIR . '/debug.log', '' );" ] );
+}
+
+/**
+ * Returns the contents of debug.log, or an empty string if WordPress
+ * has not had cause to create it.
+ */
+function readDebugLog(): string {
+	return wp( [
+		'eval',
+		`$log = WP_CONTENT_DIR . '/debug.log';
+echo file_exists( $log ) ? file_get_contents( $log ) : '';`,
 	] );
 }
 
@@ -128,5 +222,73 @@ test.describe( 'WP Display Header', () => {
 		expect( applyHeaderFilterForPost( postId, 'default-header.jpg' ) ).toBe(
 			'default-header.jpg'
 		);
+	} );
+
+	/**
+	 * Taxonomy archives — see https://github.com/obenland/wp-display-header/issues/79.
+	 *
+	 * `get_active_tax_header()` used to assign `$tt_id` only inside an
+	 * `if ( $active )` branch while reading it unconditionally in the
+	 * `apply_filters()` call below it, so an empty `wpdh_tax_meta` made
+	 * every taxonomy archive emit `Undefined variable $tt_id`.
+	 *
+	 * The returned header is *not* what pins that bug: with no option
+	 * set, the buggy code passed `false` to `get_active_header()` and
+	 * the caller's truthiness check left the header untouched — exactly
+	 * what the fixed code does with `''`. The warning was the only
+	 * observable difference, so that is what the first test asserts on.
+	 * It reads debug.log rather than the rendered page: `display_errors`
+	 * is off in the wp-env PHP image, so the warning never reaches the
+	 * response body, but .wp-env.json sets `WP_DEBUG_LOG`.
+	 */
+	test.describe( 'taxonomy archives', () => {
+		test( 'render without PHP warnings when wpdh_tax_meta is unset', async ( {
+			page,
+		} ) => {
+			const { termId } = createCategoryWithPost( 'Unset Tax Meta' );
+
+			wp( [ 'eval', "delete_option( 'wpdh_tax_meta' );" ] );
+			truncateDebugLog();
+
+			const response = await page.goto( `/?cat=${ termId }` );
+			expect( response?.status() ).toBe( 200 );
+
+			expect( readDebugLog() ).not.toContain( 'Undefined variable' );
+		} );
+
+		test( 'theme_mod_header_image filter returns the override saved for the term', () => {
+			const { termId, ttId } =
+				createCategoryWithPost( 'Override Tax Meta' );
+
+			// The same option shape the edit_term handler writes:
+			// `$term_meta[ $tt_id ] = <url>; update_option( 'wpdh_tax_meta', $term_meta );`
+			wp( [
+				'eval',
+				`update_option( 'wpdh_tax_meta', array( ${ ttId } => '${ OVERRIDE_URL }' ) );`,
+			] );
+
+			expect(
+				applyHeaderFilterForCategory( termId, 'default-header.jpg' )
+			).toBe( OVERRIDE_URL );
+		} );
+
+		test( 'theme_mod_header_image filter passes through when wpdh_tax_meta is not an array', () => {
+			const { termId } = createCategoryWithPost( 'Scalar Tax Meta' );
+
+			/*
+			 * The plugin only ever writes an array, but an older version or a
+			 * manual update could leave a scalar behind. Indexing a string by
+			 * the term taxonomy ID yields a single character, which would then
+			 * be served as the header URL.
+			 */
+			wp( [
+				'eval',
+				"update_option( 'wpdh_tax_meta', str_repeat( 'x', 500 ) );",
+			] );
+
+			expect(
+				applyHeaderFilterForCategory( termId, 'default-header.jpg' )
+			).toBe( 'default-header.jpg' );
+		} );
 	} );
 } );


### PR DESCRIPTION
## Root cause

`get_active_tax_header()` assigned `$tt_id` only inside the `if ( $active )` branch, but read it unconditionally when passing it to the `wpdh_get_active_tax_header` filter:

```php
$active = get_option( 'wpdh_tax_meta', false );

if ( $active ) {
	$tt_id  = get_queried_object()->term_taxonomy_id;
	$active = isset( $active[ $tt_id ] ) ? $active[ $tt_id ] : '';
}

return apply_filters( 'wpdh_get_active_tax_header', $this->get_active_header( $active ), $tt_id );
```

On any taxonomy archive where `wpdh_tax_meta` is falsy — a fresh install, or after the option is cleared — PHP emits `Undefined variable $tt_id` and the filter receives an undefined value. The variable being branch-scoped is the whole of it; nothing else was wrong.

## Fix

Resolve the term taxonomy ID from the queried object before the lookup, so it is always defined, and only read the stored header when both an ID and a matching entry exist:

```php
$queried_object = get_queried_object();
$tt_id          = isset( $queried_object->term_taxonomy_id ) ? $queried_object->term_taxonomy_id : null;
$tax_meta       = get_option( 'wpdh_tax_meta', array() );
$active         = ( $tt_id && isset( $tax_meta[ $tt_id ] ) ) ? $tax_meta[ $tt_id ] : '';
```

The `isset()` guard on `term_taxonomy_id` also covers the case where the queried object is not a term, which the previous code would have warned on too.

## Behavior

`get_active_tax_header()` now returns `''` instead of `false` when no header applies. Both call sites (`theme_mod_header_image()`, `theme_mod_header_image_data()`) only test the return value for truthiness, so this is not an observable change. The filter now always gets a real term taxonomy ID, or `null`.

## Testing

`php -l` passes. Verified by inspection of both call sites; the repo has no PHPUnit suite, only Playwright e2e tests, which don't cover this path.

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)