### PR TITLE
Consolidate header submission handling

### DIFF
--- a/class-obenland-wp-display-header.php
+++ b/class-obenland-wp-display-header.php
@@ -353,7 +353,7 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 	 * Recognized keywords are passed through as-is, anything else is treated as
 	 * a URL.
 	 *
-	 * @since 8.1
+	 * @since 9 - 02.09.2026
 	 *
 	 * @param string $capability Capability required to edit the object.
 	 * @param int    $object_id  ID of the object being edited.
@@ -458,7 +458,7 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 	 * through the %s, %1$s and %2$s placeholders. URLs without one are returned
 	 * untouched, so percent-encoded characters are left alone.
 	 *
-	 * @since 8.1
+	 * @since 9 - 02.09.2026
 	 *
 	 * @param string $url Header URL.
 	 * @return string Header URL with placeholders resolved.

--- a/class-obenland-wp-display-header.php
+++ b/class-obenland-wp-display-header.php
@@ -279,20 +279,16 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 	 * @return int Post ID
 	 */
 	public function save_post( $post_ID ) {
-		if ( ( ! defined( 'DOING_AUTOSAVE' ) || ! DOING_AUTOSAVE ) &&
-			isset( $_POST[ $this->textdomain ] ) &&
-			wp_verify_nonce( $_POST[ "{$this->textdomain}-nonce" ], $this->textdomain ) //phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		) {
+		$header = $this->get_submitted_header( 'edit_post', $post_ID );
 
-			if ( isset( $_POST['wpdh-reset-header'] ) ) {
-				delete_post_meta( $post_ID, '_wpdh_display_header' );
+		if ( null === $header ) {
+			return $post_ID;
+		}
 
-			} else {
-				$non_url = in_array( $_POST[ $this->textdomain ], array( 'random', 'remove-header' ), true );
-				$value   = $non_url ? $_POST[ $this->textdomain ] : esc_url_raw( wp_unslash( $_POST[ $this->textdomain ] ) ); //phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-
-				update_post_meta( $post_ID, '_wpdh_display_header', $value );
-			}
+		if ( '' === $header ) {
+			delete_post_meta( $post_ID, '_wpdh_display_header' );
+		} else {
+			update_post_meta( $post_ID, '_wpdh_display_header', $header );
 		}
 
 		return $post_ID;
@@ -308,21 +304,21 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 	 * @return int Term ID
 	 */
 	public function edit_term( $term_id, $tt_id ) {
-		if ( ( ! defined( 'DOING_AUTOSAVE' ) || ! DOING_AUTOSAVE ) &&
-			isset( $_POST[ $this->textdomain ] ) &&
-			wp_verify_nonce( $_POST[ "{$this->textdomain}-nonce" ], $this->textdomain ) //phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		) {
-			$term_meta = get_option( 'wpdh_tax_meta', array() );
+		$header = $this->get_submitted_header( 'edit_term', $term_id );
 
-			if ( isset( $_POST['wpdh-reset-header'] ) ) {
-				unset( $term_meta[ $tt_id ] );
-			} else {
-				$non_url             = in_array( $_POST[ $this->textdomain ], array( 'random', 'remove-header' ), true );
-				$term_meta[ $tt_id ] = $non_url ? $_POST[ $this->textdomain ] : esc_url_raw( $_POST[ $this->textdomain ] );  //phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-			}
-
-			update_option( 'wpdh_tax_meta', $term_meta );
+		if ( null === $header ) {
+			return $term_id;
 		}
+
+		$term_meta = (array) get_option( 'wpdh_tax_meta', array() );
+
+		if ( '' === $header ) {
+			unset( $term_meta[ $tt_id ] );
+		} else {
+			$term_meta[ $tt_id ] = $header;
+		}
+
+		update_option( 'wpdh_tax_meta', $term_meta );
 
 		return $term_id;
 	}
@@ -336,22 +332,61 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 	 * @return int User ID
 	 */
 	public function update_user( $user_id ) {
-		if ( ( ! defined( 'DOING_AUTOSAVE' ) || ! DOING_AUTOSAVE ) &&
-			isset( $_POST[ $this->textdomain ] ) &&
-			wp_verify_nonce( $_POST[ "{$this->textdomain}-nonce" ], $this->textdomain ) //phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		) {
+		$header = $this->get_submitted_header( 'edit_user', $user_id );
 
-			if ( isset( $_POST['wpdh-reset-header'] ) ) {
-				delete_user_meta( $user_id, $this->textdomain );
-			} else {
-				$non_url = in_array( $_POST[ $this->textdomain ], array( 'random', 'remove-header' ), true );
-				$value   = $non_url ? $_POST[ $this->textdomain ] : esc_url_raw( $_POST[ $this->textdomain ] );  //phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		if ( null === $header ) {
+			return $user_id;
+		}
 
-				update_user_meta( $user_id, $this->textdomain, $value );
-			}
+		if ( '' === $header ) {
+			delete_user_meta( $user_id, $this->textdomain );
+		} else {
+			update_user_meta( $user_id, $this->textdomain, $header );
 		}
 
 		return $user_id;
+	}
+
+	/**
+	 * Returns the header selection submitted for an object the current user may edit.
+	 *
+	 * Recognized keywords are passed through as-is, anything else is treated as
+	 * a URL.
+	 *
+	 * @since 8.1
+	 *
+	 * @param string $capability Capability required to edit the object.
+	 * @param int    $object_id  ID of the object being edited.
+	 * @return string|null Header keyword or URL, an empty string when the stored
+	 *                     header should be dropped, or null when the request
+	 *                     carries nothing to save.
+	 */
+	protected function get_submitted_header( $capability, $object_id ) {
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return null;
+		}
+
+		if ( ! isset( $_POST[ $this->textdomain ], $_POST[ "{$this->textdomain}-nonce" ] ) ) {
+			return null;
+		}
+
+		$nonce = sanitize_text_field( wp_unslash( $_POST[ "{$this->textdomain}-nonce" ] ) );
+
+		if ( ! wp_verify_nonce( $nonce, $this->textdomain ) || ! current_user_can( $capability, $object_id ) ) {
+			return null;
+		}
+
+		if ( isset( $_POST['wpdh-reset-header'] ) || ! is_scalar( $_POST[ $this->textdomain ] ) ) {
+			return '';
+		}
+
+		$value = sanitize_text_field( wp_unslash( $_POST[ $this->textdomain ] ) );
+
+		if ( in_array( $value, array( 'random', 'remove-header' ), true ) ) {
+			return $value;
+		}
+
+		return esc_url_raw( $value );
 	}
 
 	/**
@@ -376,11 +411,7 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 
 		foreach ( array_keys( $headers ) as $header ) {
 			foreach ( array( 'url', 'thumbnail_url' ) as $url ) {
-				$headers[ $header ][ $url ] = sprintf(
-					$headers[ $header ][ $url ],
-					get_template_directory_uri(),
-					get_stylesheet_directory_uri()
-				);
+				$headers[ $header ][ $url ] = $this->expand_header_url( $headers[ $header ][ $url ] );
 			}
 		}
 
@@ -420,6 +451,30 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 			<span class="description"><?php esc_html_e( 'This will restore the original header image. You will not be able to restore any customizations.', 'wp-display-header' ); ?></span>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Fills in the template directory placeholders of a header URL.
+	 *
+	 * Registered headers may reference the template or stylesheet directory
+	 * through sprintf placeholders. URLs that carry anything else are returned
+	 * untouched.
+	 *
+	 * @since 8.1
+	 *
+	 * @param string $url Header URL.
+	 * @return string Header URL with placeholders resolved.
+	 */
+	protected function expand_header_url( $url ) {
+		if ( ! is_string( $url ) || false === strpos( $url, '%' ) ) {
+			return (string) $url;
+		}
+
+		try {
+			return sprintf( $url, get_template_directory_uri(), get_stylesheet_directory_uri() );
+		} catch ( Throwable $e ) {
+			return $url;
+		}
 	}
 
 	/**
@@ -541,11 +596,7 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 	protected function get_active_header( $header, $raw = false ) {
 		if ( 'random' === $header && ! $raw ) {
 			$headers = $this->get_headers();
-			$header  = sprintf(
-				$headers[ array_rand( $headers ) ]['url'],
-				get_template_directory_uri(),
-				get_stylesheet_directory_uri()
-			);
+			$header  = $this->expand_header_url( $headers[ array_rand( $headers ) ]['url'] );
 		}
 
 		/**

--- a/class-obenland-wp-display-header.php
+++ b/class-obenland-wp-display-header.php
@@ -380,13 +380,11 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 			return '';
 		}
 
-		$value = sanitize_text_field( wp_unslash( $_POST[ $this->textdomain ] ) );
-
-		if ( in_array( $value, array( 'random', 'remove-header' ), true ) ) {
-			return $value;
+		if ( in_array( $_POST[ $this->textdomain ], array( 'random', 'remove-header' ), true ) ) {
+			return sanitize_key( wp_unslash( $_POST[ $this->textdomain ] ) );
 		}
 
-		return esc_url_raw( $value );
+		return esc_url_raw( wp_unslash( $_POST[ $this->textdomain ] ) );
 	}
 
 	/**
@@ -457,8 +455,8 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 	 * Fills in the template directory placeholders of a header URL.
 	 *
 	 * Registered headers may reference the template or stylesheet directory
-	 * through sprintf placeholders. URLs that carry anything else are returned
-	 * untouched.
+	 * through the %s, %1$s and %2$s placeholders. URLs without one are returned
+	 * untouched, so percent-encoded characters are left alone.
 	 *
 	 * @since 8.1
 	 *
@@ -466,7 +464,7 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 	 * @return string Header URL with placeholders resolved.
 	 */
 	protected function expand_header_url( $url ) {
-		if ( ! is_string( $url ) || false === strpos( $url, '%' ) ) {
+		if ( ! is_string( $url ) || ! preg_match( '/%(?:\d+\$)?s/', $url ) ) {
 			return (string) $url;
 		}
 

--- a/class-obenland-wp-plugins-v5.php
+++ b/class-obenland-wp-plugins-v5.php
@@ -125,8 +125,8 @@ class Obenland_Wp_Plugins_V5 {
 		if ( $this->plugin_name === $plugin_file ) {
 			$plugin_meta[] = sprintf(
 				'<a href="%1$s" target="_blank" title="%2$s">%2$s</a>',
-				$this->donate_link,
-				__( 'Donate', 'obenland-wp' )
+				esc_url( $this->donate_link ),
+				esc_attr__( 'Donate', 'obenland-wp' )
 			);
 		}
 

--- a/class-obenland-wp-plugins-v5.php
+++ b/class-obenland-wp-plugins-v5.php
@@ -123,10 +123,13 @@ class Obenland_Wp_Plugins_V5 {
 	 */
 	public function plugin_row_meta( $plugin_meta, $plugin_file ) {
 		if ( $this->plugin_name === $plugin_file ) {
+			$label = __( 'Donate', 'obenland-wp' );
+
 			$plugin_meta[] = sprintf(
-				'<a href="%1$s" target="_blank" title="%2$s">%2$s</a>',
+				'<a href="%1$s" target="_blank" title="%2$s">%3$s</a>',
 				esc_url( $this->donate_link ),
-				esc_attr__( 'Donate', 'obenland-wp' )
+				esc_attr( $label ),
+				esc_html( $label )
 			);
 		}
 


### PR DESCRIPTION
The three save handlers — `save_post()`, `edit_term()` and `update_user()` — each carried their own near-identical copy of the autosave check, nonce lookup and value resolution. They had drifted apart in small ways: only `save_post()` unslashed before `esc_url_raw()`, and all three read the nonce field without first checking it was there, which warns on PHP 8 when the header field is posted on its own.

This folds that shared preamble into one `get_submitted_header()`, which resolves the posted value once and confirms the current user may edit the object it is being saved against. Each caller is left with just its storage decision — post meta, the taxonomy option, or user meta — which is the part that genuinely differs. Keeping every `$_POST` read in the same function as the nonce check also means the three `WordPress.Security.ValidatedSanitizedInput` annotations are no longer needed.

The helper returns `null` when there is nothing to save and an empty string when the stored header should be dropped, so the reset button and an unusable submission collapse to the same path.

A few smaller things while in here:

- Both header URL `sprintf()` call sites now go through `expand_header_url()`. It leaves a URL alone unless it actually contains a placeholder, and tolerates one that does not match the expected argument list — a stray specifier used to raise an `ArgumentCountError` on PHP 8.
- `plugin_row_meta()` escapes the donate link and its label.
- `wpdh_tax_meta` is cast to an array before being indexed, matching how `get_active_tax_header()` already guards it.

No change to the stored data format or to what the form submits.

## Testing

- `vendor/bin/phpcs --standard=WordPress` clean, same as before the change.
- `npx playwright test` — 6 passed.

Note that the e2e suite writes meta directly via wp-cli, so it covers the read path but not these handlers; the save path is still uncovered either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)