### PR TITLE
Make the reset button work with no header selected

### DIFF
--- a/class-obenland-wp-display-header.php
+++ b/class-obenland-wp-display-header.php
@@ -366,7 +366,7 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 			return null;
 		}
 
-		if ( ! isset( $_POST[ $this->textdomain ], $_POST[ "{$this->textdomain}-nonce" ] ) ) {
+		if ( ! isset( $_POST[ "{$this->textdomain}-nonce" ] ) ) {
 			return null;
 		}
 
@@ -376,7 +376,15 @@ class Obenland_Wp_Display_Header extends Obenland_Wp_Plugins_V5 {
 			return null;
 		}
 
-		if ( isset( $_POST['wpdh-reset-header'] ) || ! is_scalar( $_POST[ $this->textdomain ] ) ) {
+		if ( isset( $_POST['wpdh-reset-header'] ) ) {
+			return '';
+		}
+
+		if ( ! isset( $_POST[ $this->textdomain ] ) ) {
+			return null;
+		}
+
+		if ( ! is_scalar( $_POST[ $this->textdomain ] ) ) {
 			return '';
 		}
 

--- a/class-obenland-wp-plugins-v5.php
+++ b/class-obenland-wp-plugins-v5.php
@@ -126,7 +126,7 @@ class Obenland_Wp_Plugins_V5 {
 			$label = __( 'Donate', 'obenland-wp' );
 
 			$plugin_meta[] = sprintf(
-				'<a href="%1$s" target="_blank" title="%2$s">%3$s</a>',
+				'<a href="%1$s" target="_blank" rel="noopener noreferrer" title="%2$s">%3$s</a>',
 				esc_url( $this->donate_link ),
 				esc_attr( $label ),
 				esc_html( $label )

--- a/tests/phpunit/class-wpdh-edit-term-test.php
+++ b/tests/phpunit/class-wpdh-edit-term-test.php
@@ -107,6 +107,18 @@ class Wpdh_Edit_Term_Test extends Wpdh_Test_Case {
 	}
 
 	/**
+	 * Reset works when no radio is selected.
+	 */
+	public function test_reset_without_selection_removes_entry() {
+		update_option( 'wpdh_tax_meta', array( $this->tt_id => 'https://example.com/old.jpg' ) );
+
+		$this->post_as( $this->admin_id, null, array( 'wpdh-reset-header' => 'Restore' ) );
+		$this->plugin->edit_term( $this->term_id, $this->tt_id );
+
+		$this->assertSame( '', $this->stored_header() );
+	}
+
+	/**
 	 * A valid nonce alone is not enough without the capability.
 	 */
 	public function test_ignores_user_without_capability() {

--- a/tests/phpunit/class-wpdh-save-post-test.php
+++ b/tests/phpunit/class-wpdh-save-post-test.php
@@ -107,6 +107,21 @@ class Wpdh_Save_Post_Test extends Wpdh_Test_Case {
 	}
 
 	/**
+	 * Reset works when no radio is selected.
+	 *
+	 * The form renders with nothing checked while no header has been chosen, so
+	 * the browser omits the field entirely and only the reset button arrives.
+	 */
+	public function test_reset_without_selection_deletes_meta() {
+		update_post_meta( $this->post_id, '_wpdh_display_header', 'https://example.com/old.jpg' );
+
+		$this->post_as( $this->editor_id, null, array( 'wpdh-reset-header' => 'Restore' ) );
+		$this->plugin->save_post( $this->post_id );
+
+		$this->assertSame( '', $this->stored_header() );
+	}
+
+	/**
 	 * A request without a nonce field is ignored, and warns about nothing.
 	 */
 	public function test_ignores_request_without_nonce() {

--- a/tests/phpunit/class-wpdh-update-user-test.php
+++ b/tests/phpunit/class-wpdh-update-user-test.php
@@ -105,6 +105,18 @@ class Wpdh_Update_User_Test extends Wpdh_Test_Case {
 	}
 
 	/**
+	 * Reset works when no radio is selected.
+	 */
+	public function test_reset_without_selection_deletes_meta() {
+		update_user_meta( $this->subscriber_id, 'wp-display-header', 'https://example.com/old.jpg' );
+
+		$this->post_as( $this->subscriber_id, null, array( 'wpdh-reset-header' => 'Restore' ) );
+		$this->plugin->update_user( $this->subscriber_id );
+
+		$this->assertSame( '', $this->stored_header( $this->subscriber_id ) );
+	}
+
+	/**
 	 * A request carrying a bad nonce is ignored.
 	 */
 	public function test_ignores_invalid_nonce() {


### PR DESCRIPTION
Picks up the two review comments left open when #82 merged. Stacked on #84 so the fix ships with regression tests — retarget to `trunk` once that lands.

## The reset bug

`get_submitted_header()` opened with:

```php
if ( ! isset( $_POST[ $this->textdomain ], $_POST[ "{$this->textdomain}-nonce" ] ) ) {
	return null;
}
```

A browser omits an unselected radio group from the request entirely. The header form renders with nothing checked whenever no header has been chosen yet — which is exactly when `$active` is empty — so clicking **Restore Original Header Image** sent only `wpdh-reset-header` and the nonce. The guard saw no header field, returned `null`, and the stored header survived. Reset did nothing in precisely the state where it is the only available action.

Now the nonce is required up front, the reset button is checked before the header field, and the header field is required only when not resetting. A request carrying neither still returns `null` and changes nothing, so `test_ignores_request_without_header_field` is unaffected.

## The link attribute

`plugin_row_meta()` opens the donate link with `target="_blank"` and no `rel`. Added `rel="noopener noreferrer"`.

## Verification

Three regression tests, one per save handler, each asserting a stored header is dropped when only the reset button is submitted. Against the previous helper:

```
1) Wpdh_Edit_Term_Test::test_reset_without_selection_removes_entry
2) Wpdh_Save_Post_Test::test_reset_without_selection_deletes_meta
3) Wpdh_Update_User_Test::test_reset_without_selection_deletes_meta
Tests: 34, Assertions: 36, Failures: 3.
```

With the fix: `OK (34 tests, 36 assertions)`. PHPCS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)