### PR TITLE
Prepare version 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Tags: header image, custom header, display header, dynamic, posts
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MWUA92KA2TL6Q
 Requires at least: 3.2
 Tested up to: 7.1
-Stable tag: 8
+Requires PHP: 7.4
+Stable tag: 9
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -59,6 +60,21 @@ See TwentyTwelve's `header.php` for reference.
 
 
 ## Changelog
+
+### 9
+* Fixed the Restore Original Header Image button doing nothing when no header had been selected yet.
+* Fixed header URLs containing percent-encoded characters, such as non-ASCII file names, being corrupted when saved.
+* Fixed a PHP warning on taxonomy archives when the queried object is not a term. See https://github.com/obenland/wp-display-header/issues/79
+* Header selections are now checked against the current user's capabilities before being saved.
+* Corrected escaping of the donate link on the plugins screen.
+* Added a PHPUnit test suite covering the post, term and profile save handlers.
+* This release requires PHP 7.4 or later.
+* Tested for WordPress 7.1.
+
+### 8
+* Maintenance release. No functional changes.
+* Added end-to-end tests and refreshed the development tooling.
+* Tested for WordPress 6.9.
 
 ### 7
 * Fixes a bug where posts pages would not load their assigned header image. See https://github.com/obenland/wp-display-header/issues/3

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require": {
-    "php": "^7.2|^8.0"
+    "php": "^7.4|^8.0"
   },
   "require-dev": {
     "dealerdirect/phpcodesniffer-composer-installer": "^1.2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a20fa110c9453481e517f30db30159dd",
+    "content-hash": "0887e74cbc51d3f7bd2fa9bf248fdf90",
     "packages": [],
     "packages-dev": [
         {
@@ -2321,7 +2321,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2|^8.0"
+        "php": "^7.4|^8.0"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-display-header",
-	"version": "7.0.0",
+	"version": "9.0.0",
 	"private": true,
 	"description": "Specify a header image per post and per taxonomy/author archive.",
 	"devDependencies": {

--- a/wp-display-header.php
+++ b/wp-display-header.php
@@ -1,14 +1,15 @@
 <?php
 /**
- * Plugin Name: WP Display Header
- * Plugin URI:  http://en.wp.obenland.it/wp-display-header/?utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-display-header
- * Description: This plugin lets you specify a header image for each post and taxonomy/author archive page individually, from your default headers and custom headers.
- * Version:     8
- * Author:      Konstantin Obenland
- * Author URI:  http://en.wp.obenland.it/?utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-display-header
- * Text Domain: wp-display-header
- * Domain Path: /lang
- * License:     GPLv2
+ * Plugin Name:  WP Display Header
+ * Plugin URI:   http://en.wp.obenland.it/wp-display-header/?utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-display-header
+ * Description:  This plugin lets you specify a header image for each post and taxonomy/author archive page individually, from your default headers and custom headers.
+ * Version:      9
+ * Author:       Konstantin Obenland
+ * Author URI:   http://en.wp.obenland.it/?utm_source=wordpress&utm_medium=plugin&utm_campaign=wp-display-header
+ * Requires PHP: 7.4
+ * Text Domain:  wp-display-header
+ * Domain Path:  /lang
+ * License:      GPLv2
  *
  * @package wp-display-header
  */


### PR DESCRIPTION
Release prep only — no behaviour changes. Everything shipping in 9 is already on trunk.

Deploy runs from `.github/workflows/deploy.yml` on any pushed tag, so **merging this does not publish anything**. Pushing the tag `9` afterwards is what triggers the WordPress.org deploy, and I've left that to you.

## Changes

| File | Change |
| --- | --- |
| `wp-display-header.php` | `Version: 8` → `9`, added `Requires PHP: 7.4`, header block realigned |
| `README.md` | `Stable tag: 8` → `9`, added `Requires PHP: 7.4`, changelog for 9 and 8 |
| `composer.json` | `require.php` `^7.2\|^8.0` → `^7.4\|^8.0` |
| `composer.lock` | content hash only — no package versions changed |
| `package.json` | `7.0.0` → `9.0.0` |

## On the PHP requirement

`Requires PHP: 7.4` would have contradicted `composer.json`'s `^7.2|^8.0`, so that moves too. Resolution is unchanged: `config.platform.php` was already pinned to `7.4.0`, so the lock diff is 2 lines and no package moved.

## On the version 8 backfill

Version 8 shipped with no changelog entry at all. Checked what was actually in it — between tags `7` and `8` the only PHP change was the version line itself (`wp-display-header.php | 2 +-`); everything else was the readme.txt → README.md conversion, the first Playwright tests, WPCS 3.x and Actions updates. The backfilled entry says so rather than inventing user-facing changes.

## Readme validation

Ran the WordPress.org readme validator. No warnings, and nothing flagged on the header block, `Stable tag`, `Requires PHP` or changelog format. Two non-issues:

- `trademarked_name` — objects to the name beginning with "wp". That governs *new* plugin permalinks and display names; this plugin has been in the directory as `wp-display-header` since 2011 and is grandfathered. The validator cannot tell it is checking an existing plugin.
- `low_usage_tags` — `display header` is not widely used. Cosmetic.

## Not changed

`Requires at least: 3.2` is still the declared WordPress floor, which is long out of date. Left alone as out of scope for a release commit — worth a separate look.

## Verification

PHPCS clean, `OK (34 tests, 36 assertions)`, `composer validate` passes and the lock installs cleanly. Confirmed `.distignore` keeps `tests/`, `phpunit.xml.dist`, `.wp-env.test.json`, `composer.*` and `vendor/` out of the built package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)